### PR TITLE
Enables VirtualBox basic USB Controller

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
    config.vm.provider "virtualbox" do |vb|
      vb.customize ["modifyvm", :id, "--memory", "4096"]
+     vb.customize ["modifyvm", :id, "--usb", "on"]
    end
 
 


### PR DESCRIPTION
Software in the ODM collection of applications require a live USB controller or they will error. This change causes VirtualBox to enable its USB controller emulation feature. It does not enable the the VirtualBox USB 2.0 support as that is not required to get the ODM software to run without error.
